### PR TITLE
 Packaging Spring Application to WAR Closes #3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <groupId>com.appsdevblog.app.ws</groupId>
     <artifactId>mobile-app-ws</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+    <packaging>war</packaging>
     <name>mobile-app-ws</name>
     <description>Demo project for Spring Boot</description>
 
@@ -52,6 +53,12 @@
             <version>0.9.1</version>
         </dependency>
 
+        <!-- spring-boot-starter-tomcat dependency will be provided at the run time rather than compile time -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/appsdevblog/app/ws/MobileAppWsApplication.java
+++ b/src/main/java/com/appsdevblog/app/ws/MobileAppWsApplication.java
@@ -3,11 +3,24 @@ package com.appsdevblog.app.ws;
 import com.appsdevblog.app.ws.security.AppProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
-public class MobileAppWsApplication {
+public class MobileAppWsApplication extends SpringBootServletInitializer {
+
+    /**
+     * Extends SpringBootServletInitializer class and override configure method
+     * in order to package this application as a Web Archive (WAR), change the packaging in pom.xml
+     * to WAR and add spring-boot-starter-tomcat dependency with provided scope
+     **/
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(MobileAppWsApplication.class);
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(MobileAppWsApplication.class, args);


### PR DESCRIPTION
Extends SpringBootServletInitializer class and override configure method in order to package this application as a Web Archive (WAR), change the packaging in pom.xml to WAR and add spring-boot-starter-tomcat dependency with provided scope.